### PR TITLE
Fix checkpointer bugs and simplify telemetry/metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ git submodule update --init
 
 ```
 sudo apt-get update
-sudo apt-get install -y pkg-config libssl-dev clang libclang-dev build-essential ninja-build cmake cpufrequtils htop python3-pip
+sudo apt-get install -y pkg-config libssl-dev clang libclang-dev build-essential ninja-build cmake cpufrequtils htop python3-pip libgtest-dev
 pip install numpy
 ```
 

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -74,7 +74,7 @@ endif()
 target_include_directories(ycsb PRIVATE ${ROCKSDB_INCLUDE_DIR})
 target_link_libraries(ycsb PRIVATE ${ROCKSDB_LIBRARY})
 target_link_libraries(ycsb PRIVATE -lgflags -lsnappy -lz -lbz2 -llz4 -lzstd)
-target_link_libraries(ycsb PRIVATE -labsl_hash -labsl_raw_hash_set)
+#target_link_libraries(ycsb PRIVATE -labsl_hash -labsl_raw_hash_set)
 
 # Commenting out all TPCC-related sections
 #add_custom_command(

--- a/src/doradd/checkpointer.hpp
+++ b/src/doradd/checkpointer.hpp
@@ -80,12 +80,6 @@ namespace batch_helpers {
   }
 }
 
-struct BatchMetrics {
-  std::atomic<size_t> total_bytes{0};
-  std::atomic<size_t> successful{0};
-  std::atomic<uint64_t> total_us{0};
-};
-
 template<typename StorageType, typename TxnType, typename RowType = TxnType>
 class Checkpointer {
 public:
@@ -172,7 +166,7 @@ public:
             // serialize the row
             std::string data(reinterpret_cast<const char*>(&obj), sizeof(RowType));
             // write under "<row_id>_v<version_id>"
-            std::string versioned_key = std::to_string(*key_ptr) + "_v" + std::to_string(snap);
+            std::string versioned_key = std::to_string(key_ptr[i]) + "_v" + std::to_string(snap);
             storage.add_to_batch(batch, versioned_key, data);
         }
         storage.commit_batch(batch);

--- a/src/doradd/dispatcher.hpp
+++ b/src/doradd/dispatcher.hpp
@@ -618,15 +618,9 @@ struct Spawner
         fprintf(res_throughput_fd, 
           "exec  - %lf tx/s\n", (tx_exec_sum - last_tx_exec_sum) / dur_cnt);
         fprintf(res_throughput_fd, "Number of checkpoints: %lu\n", checkpointer->get_total_checkpoints());
-        for (size_t i = 0; i < checkpointer->get_total_checkpoints(); i++) {
-          fprintf(res_throughput_fd, "Checkpoint %lu: %lf\n", i, checkpointer->get_interval_ms(i));
-        }
+
         fflush(res_throughput_fd);
         fclose(res_throughput_fd);
-        
-        // Print checkpoint intervals and transaction counts
-        checkpointer->print_intervals();
-        checkpointer->print_tx_counts();
         
 #ifdef RPC_LATENCY
         // fprintf(res_log_fd, "%lf\n", tx_count / dur_cnt);


### PR DESCRIPTION
- README: add libgtest-dev to the Ubuntu prerequisites.
- CMake (app/CMakeLists.txt): comment out Abseil hash/raw_hash_set links for the ycsb target; leave checkpoint DB path define unchanged.

Several metrics such as intervals btw snapshots are unnecessary, the out figure in eval I expect is to be things like whole system throughput, latency, etc. I aggressively removed this part in the checkpointer.hpp, if necessary in my further dev, I plan to add them as standalone log service instead of mixing with core logic code of checkpointer.

-  Runtime (src/doradd/checkpointer.hpp)
	- remove per-checkpoint interval/tx tracking, metadata bitset recovery, and transaction-count bookkeeping during checkpoints; 
	- correct versioned key construction; (**important!**)
	- bump checkpoint counter when completion batches finish; 
	- keep recovery of total txns and snapshot tracking; 
	- destructor now joins completion thread.
- Dispatcher logging (src/doradd/dispatcher.hpp): reduce spawn throughput reporting to omit printing per-checkpoint intervals and tx-count dumps.

I will look at GC in the next step/PR probably.